### PR TITLE
Refactor example to enable vmapping and insert bwd all-reduces.

### DIFF
--- a/test.py
+++ b/test.py
@@ -228,14 +228,14 @@ def _layernorm(x, gamma, beta, layernorm_type, zero_centered_gamma, epsilon):
 
 def func(x, gamma, beta, y1, y2):
     if TEST_CASE == 0:
-        x, _, _ = _layernorm(x, gamma, beta, None, False, 1e-6)
+        x = _layernorm(x, gamma, beta, None, False, 1e-6)
         x = jnp.dot(x, y1)
         out = jnp.dot(x, y2)
         return jnp.mean(out)
     else:
         x = jnp.dot(x, y1)
         x = jnp.dot(x, y2)
-        out, _, _ = _layernorm(x, gamma, beta, None, False, 1e-6)
+        out = _layernorm(x, gamma, beta, None, False, 1e-6)
         return jnp.mean(out)
 
 

--- a/test.py
+++ b/test.py
@@ -64,7 +64,6 @@ def _layernorm_fwd_abstract_eval(x_aval, gamma_aval, beta_aval, *,
   # x_aval: [N1, N2, ..., Nk, H]  # NOTE: multiple leading batch axes!
   # gamma_aval: [H]
   # beta_aval: [H]
-  # epsilon_aval: []
   del gamma_aval, beta_aval, epsilon
   out_aval = core.raise_to_shaped(x_aval)
   mu_aval = rsigma_aval = out_aval.update(shape=out_aval.shape[:-1])
@@ -94,7 +93,7 @@ from jax._src.interpreters import batching
 
 def layernorm_fwd_batcher(
     batched_args: Sequence[jax.Array],
-    batch_dims: int | None,
+    batch_dims: Sequence[int | None],
     *,
     zero_centered_gamma: bool,
     epsilon: float,


### PR DESCRIPTION
Refactor the example in test.py:
1. enable vmapping by adding a wrapper primitive which accepts arbitrarily many batch dimensions, and which has a vmap rule;
2. add the explicit psums (all-reduces) required in the sharded backward pass to handle the built-in implicit broadcasts on `gamma` and `beta`.

This change requires google/jax@74bcd65. It has a helper function which should no longer be necessary after google/jax@03575c4.

Co-authored with @pschuh 